### PR TITLE
fix(validation): Accept numpy arrays in score format check

### DIFF
--- a/.github/scripts/validate_submission.py
+++ b/.github/scripts/validate_submission.py
@@ -10,6 +10,7 @@ import sys
 import time
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 REQUIRED_COLUMNS = ["model", "teleqna", "telelogs", "telemath", "3gpp_tsg", "date"]
@@ -250,13 +251,13 @@ def validate_parquet(parquet_path: Path) -> tuple[dict[str, bool], list[str]]:
     checks["model_format"] = model_format_ok
     checks["provider_recognized"] = provider_recognized
 
-    # Validate score arrays
+    # Validate score arrays (can be list, tuple, or numpy array from parquet)
     for col in ["teleqna", "telelogs", "telemath", "3gpp_tsg"]:
         if col not in df.columns:
             continue
         for idx, val in df[col].items():
             if val is not None:
-                if not isinstance(val, (list, tuple)) or len(val) < 2:
+                if not isinstance(val, (list, tuple, np.ndarray)) or len(val) < 2:
                     errors.append(f"Invalid score format in {col} row {idx}: expected [score, stderr, ...]")
 
     return checks, errors


### PR DESCRIPTION
## Summary
- Fix validator to accept `numpy.ndarray` in score format validation
- Parquet files serialize Python lists as numpy arrays, not Python lists
- The check `isinstance(val, (list, tuple))` was failing for valid numpy arrays

## Root Cause
When pandas writes a DataFrame with list columns to parquet, it serializes them as numpy arrays. When reading back, `df[col].items()` returns numpy arrays, not Python lists. The original validator only checked for `list` and `tuple` types.

## Test Plan
- [x] Verified locally that the fix accepts numpy arrays with `len >= 2`
- [ ] PR #3 should pass validation after this fix is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)