### PR TITLE
feat(validation): Support partial benchmark submissions with intelligent HF merge

### DIFF
--- a/.github/scripts/json_to_parquet.py
+++ b/.github/scripts/json_to_parquet.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Convert JSON trajectories to parquet format during validation.
+
+This script parses Inspect AI trajectory JSON files and generates a parquet file
+with the standardized leaderboard schema. It supports partial submissions where
+not all benchmarks need to be present.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+
+# Benchmark task name to column mapping
+TASK_TO_COLUMN = {
+    "teleqna": "teleqna",
+    "telelogs": "telelogs",
+    "telemath": "telemath",
+    "three_gpp": "3gpp_tsg",
+}
+
+REQUIRED_COLUMNS = ["model", "teleqna", "telelogs", "telemath", "3gpp_tsg", "date"]
+
+
+def extract_benchmark_from_task(task_name: str) -> str | None:
+    """Map Inspect AI task name to benchmark column.
+
+    Args:
+        task_name: Task name from trajectory (e.g., 'three_gpp', 'teleqna')
+
+    Returns:
+        Column name or None if not recognized
+    """
+    task_lower = task_name.lower()
+    for task_key, column in TASK_TO_COLUMN.items():
+        if task_key in task_lower:
+            return column
+    return None
+
+
+def extract_model_info(model_string: str) -> tuple[str, str]:
+    """Extract model name and provider from model string.
+
+    Handles formats like:
+    - "openrouter/openai/gpt-5-mini" -> ("gpt-5-mini", "Openai")
+    - "openai/gpt-4o" -> ("gpt-4o", "Openai")
+    - "anthropic/claude-haiku-4.5" -> ("claude-haiku-4.5", "Anthropic")
+
+    Args:
+        model_string: Model identifier from trajectory
+
+    Returns:
+        Tuple of (model_name, provider)
+    """
+    parts = model_string.split("/")
+
+    if len(parts) >= 3:
+        # Format: router/provider/model (e.g., openrouter/openai/gpt-5-mini)
+        provider = parts[1].capitalize()
+        model_name = parts[-1]
+    elif len(parts) == 2:
+        # Format: provider/model
+        provider = parts[0].capitalize()
+        model_name = parts[1]
+    else:
+        # Just model name
+        provider = "Unknown"
+        model_name = parts[0]
+
+    return model_name, provider
+
+
+def parse_trajectory_json(json_path: Path) -> dict | None:
+    """Parse a trajectory JSON file and extract score data.
+
+    Args:
+        json_path: Path to trajectory JSON file
+
+    Returns:
+        Dict with keys: benchmark, score, stderr, n_samples, model_name, provider
+        or None if parsing fails
+    """
+    try:
+        with open(json_path) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Warning: Failed to parse {json_path.name}: {e}")
+        return None
+
+    # Extract task/benchmark
+    eval_data = data.get("eval", {})
+    task_name = eval_data.get("task", "")
+    benchmark = extract_benchmark_from_task(task_name)
+
+    if not benchmark:
+        print(f"Warning: Unrecognized task '{task_name}' in {json_path.name}")
+        return None
+
+    # Extract model info
+    model_string = eval_data.get("model", "")
+    if not model_string:
+        print(f"Warning: No model found in {json_path.name}")
+        return None
+
+    model_name, provider = extract_model_info(model_string)
+
+    # Extract score from results.scores[0].metrics
+    results = data.get("results", {})
+    scores_list = results.get("scores", [])
+
+    if not scores_list:
+        print(f"Warning: No scores found in {json_path.name}")
+        return None
+
+    metrics = scores_list[0].get("metrics", {})
+    accuracy_data = metrics.get("accuracy", {})
+    stderr_data = metrics.get("stderr", {})
+
+    accuracy = accuracy_data.get("value")
+    stderr = stderr_data.get("value")
+
+    if accuracy is None:
+        print(f"Warning: No accuracy value in {json_path.name}")
+        return None
+
+    # Convert to percentage (scores are stored as 0-1 in JSON, 0-100 in parquet)
+    score = accuracy * 100
+    stderr_val = (stderr * 100) if stderr else 0.0
+
+    # Get n_samples
+    n_samples = results.get("total_samples", 0)
+
+    return {
+        "benchmark": benchmark,
+        "score": round(score, 2),
+        "stderr": round(stderr_val, 6),
+        "n_samples": float(n_samples),
+        "model_name": model_name,
+        "provider": provider,
+    }
+
+
+def generate_parquet(
+    trajectory_files: list[Path],
+    output_path: Path,
+) -> dict:
+    """Generate parquet file from trajectory JSON files.
+
+    Args:
+        trajectory_files: List of trajectory JSON file paths
+        output_path: Path for output parquet file
+
+    Returns:
+        Dict with model info and benchmarks found
+
+    Raises:
+        ValueError: If no valid trajectory data found
+    """
+    # Parse all trajectories
+    parsed_data: list[dict] = []
+    for json_path in trajectory_files:
+        result = parse_trajectory_json(json_path)
+        if result:
+            parsed_data.append(result)
+
+    if not parsed_data:
+        raise ValueError("No valid trajectory data found in any JSON files")
+
+    # Get model info (should be consistent across all trajectories)
+    model_name = parsed_data[0]["model_name"]
+    provider = parsed_data[0]["provider"]
+
+    # Verify all trajectories are from the same model
+    for data in parsed_data[1:]:
+        if data["model_name"] != model_name or data["provider"] != provider:
+            print(
+                f"Warning: Mixed models in trajectories: "
+                f"{model_name} ({provider}) vs {data['model_name']} ({data['provider']})"
+            )
+
+    # Build row with score arrays [score, stderr, n_samples]
+    row: dict = {
+        "model": f"{model_name} ({provider})",
+        "teleqna": None,
+        "telelogs": None,
+        "telemath": None,
+        "3gpp_tsg": None,
+        "date": date.today().isoformat(),
+    }
+
+    benchmarks_found = []
+    for data in parsed_data:
+        benchmark = data["benchmark"]
+        score_array = [data["score"], data["stderr"], data["n_samples"]]
+        row[benchmark] = score_array
+        benchmarks_found.append(benchmark)
+
+    # Create DataFrame and save
+    df = pd.DataFrame([row])
+    df.to_parquet(output_path)
+
+    return {
+        "model_name": model_name,
+        "provider": provider,
+        "display_name": f"{model_name} ({provider})",
+        "benchmarks_found": benchmarks_found,
+        "benchmarks_missing": [b for b in TASK_TO_COLUMN.values() if b not in benchmarks_found],
+        "output_path": str(output_path),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert JSON trajectories to parquet format"
+    )
+    parser.add_argument(
+        "--trajectory-dir",
+        required=True,
+        help="Directory containing trajectory JSON files",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory for output parquet file",
+    )
+    args = parser.parse_args()
+
+    trajectory_dir = Path(args.trajectory_dir)
+    output_dir = Path(args.output_dir)
+
+    if not trajectory_dir.exists():
+        print(f"Error: Trajectory directory not found: {trajectory_dir}")
+        sys.exit(1)
+
+    # Ensure output directory exists
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Find all JSON files
+    json_files = list(trajectory_dir.glob("*.json"))
+    if not json_files:
+        print(f"Error: No JSON files found in {trajectory_dir}")
+        sys.exit(1)
+
+    print(f"Found {len(json_files)} JSON trajectory files")
+
+    # Determine output filename from directory name
+    dir_name = trajectory_dir.name  # e.g., "openai_gpt-5-mini"
+    output_path = output_dir / f"{dir_name}.parquet"
+
+    try:
+        result = generate_parquet(json_files, output_path)
+        print(f"Generated parquet: {result['output_path']}")
+        print(f"Model: {result['display_name']}")
+        print(f"Benchmarks found: {', '.join(result['benchmarks_found'])}")
+        if result["benchmarks_missing"]:
+            print(f"Benchmarks missing: {', '.join(result['benchmarks_missing'])}")
+
+        # Write result for workflow
+        with open("conversion_result.json", "w") as f:
+            json.dump(result, f, indent=2)
+
+    except ValueError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Unexpected error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/sync_to_huggingface.py
+++ b/.github/scripts/sync_to_huggingface.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
-"""Sync validated submissions to HuggingFace dataset."""
+"""Sync validated submissions to HuggingFace dataset with intelligent merge.
+
+Supports partial submissions by:
+- Only updating benchmark columns that are submitted
+- Preserving existing scores for non-submitted benchmarks
+- Generating a sync report showing what was updated
+"""
 
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 from pathlib import Path
@@ -13,6 +20,7 @@ from datasets import Dataset
 
 
 DATASET_REPO = "GSMA/leaderboard"
+BENCHMARK_COLUMNS = ["teleqna", "telelogs", "telemath", "3gpp_tsg"]
 
 
 def load_existing_dataset(token: str) -> pd.DataFrame:
@@ -38,29 +46,103 @@ def load_existing_dataset(token: str) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def merge_dataframes(existing_df: pd.DataFrame, new_df: pd.DataFrame) -> pd.DataFrame:
-    """Merge new entries with existing data.
-
-    Updates existing rows or adds new ones based on model name.
+def is_null_score(value) -> bool:
+    """Check if a score value is null/missing.
 
     Args:
-        existing_df: Existing leaderboard data
+        value: Score value to check (can be None, list, array, etc.)
+
+    Returns:
+        True if the score is considered null/missing
+    """
+    if value is None:
+        return True
+    if pd.isna(value) if not isinstance(value, (list, tuple)) else False:
+        return True
+    # Check for empty lists/arrays
+    if isinstance(value, (list, tuple)) and len(value) == 0:
+        return True
+    return False
+
+
+def merge_with_preservation(
+    existing_df: pd.DataFrame,
+    new_df: pd.DataFrame,
+) -> tuple[pd.DataFrame, dict]:
+    """Merge new entries with existing data, intelligently preserving scores.
+
+    Logic:
+    - If model EXISTS in existing_df:
+        - For each benchmark column in new_df:
+            - If new value is not null: update (overwrite submitted benchmarks)
+            - If new value is null: keep existing value
+    - If model is NEW: add entire row
+
+    Args:
+        existing_df: Current leaderboard data
         new_df: New submission data
 
     Returns:
-        Merged DataFrame with duplicates resolved
+        Tuple of (merged DataFrame, sync report dict)
     """
+    sync_report: dict = {
+        "new_models": [],
+        "updated_models": [],
+        "updated_scores": [],
+        "preserved_scores": [],
+    }
+
     if existing_df.empty:
-        return new_df
+        sync_report["new_models"] = new_df["model"].tolist()
+        return new_df.copy(), sync_report
 
     if new_df.empty:
-        return existing_df
+        return existing_df.copy(), sync_report
 
-    # Combine and deduplicate by model name (keep new version)
-    combined_df = pd.concat([existing_df, new_df], ignore_index=True)
-    combined_df = combined_df.drop_duplicates(subset=["model"], keep="last")
+    result_df = existing_df.copy()
+    existing_models = set(existing_df["model"].tolist())
 
-    return combined_df
+    for _, new_row in new_df.iterrows():
+        model_name = new_row["model"]
+
+        if model_name in existing_models:
+            # Model EXISTS - intelligent merge
+            idx = result_df[result_df["model"] == model_name].index[0]
+
+            model_updated = False
+            for col in BENCHMARK_COLUMNS:
+                new_val = new_row.get(col)
+                existing_val = result_df.at[idx, col]
+
+                new_is_null = is_null_score(new_val)
+                existing_is_null = is_null_score(existing_val)
+
+                if not new_is_null:
+                    # New submission has a score for this benchmark - UPDATE
+                    result_df.at[idx, col] = new_val
+                    model_updated = True
+
+                    if existing_is_null:
+                        sync_report["updated_scores"].append(f"{model_name}:{col} (new)")
+                    else:
+                        sync_report["updated_scores"].append(f"{model_name}:{col} (updated)")
+                elif not existing_is_null:
+                    # New is null but existing has a value - PRESERVE
+                    sync_report["preserved_scores"].append(f"{model_name}:{col}")
+
+            # Update date if any scores were updated
+            if model_updated:
+                if "date" in new_row and new_row["date"]:
+                    result_df.at[idx, "date"] = new_row["date"]
+                sync_report["updated_models"].append(model_name)
+
+        else:
+            # Model is NEW - add entire row
+            new_row_df = pd.DataFrame([new_row])
+            result_df = pd.concat([result_df, new_row_df], ignore_index=True)
+            sync_report["new_models"].append(model_name)
+
+    return result_df, sync_report
 
 
 def upload_to_huggingface(df: pd.DataFrame, token: str) -> None:
@@ -137,9 +219,25 @@ def main() -> None:
     existing_df = load_existing_dataset(hf_token)
     print(f"Existing entries: {len(existing_df)}")
 
-    # Merge
-    merged_df = merge_dataframes(existing_df, new_df)
+    # Intelligent merge with preservation
+    merged_df, sync_report = merge_with_preservation(existing_df, new_df)
     print(f"Merged entries: {len(merged_df)}")
+
+    # Log sync report
+    print("\n=== Sync Report ===")
+    if sync_report.get("new_models"):
+        print(f"New models added: {sync_report['new_models']}")
+    if sync_report.get("updated_models"):
+        print(f"Models updated: {sync_report['updated_models']}")
+    if sync_report.get("updated_scores"):
+        print(f"Scores updated: {sync_report['updated_scores']}")
+    if sync_report.get("preserved_scores"):
+        print(f"Scores preserved: {sync_report['preserved_scores']}")
+    print("==================\n")
+
+    # Write sync report for workflow to post as comment
+    with open("sync_report.json", "w") as f:
+        json.dump(sync_report, f, indent=2)
 
     # Upload
     print("Uploading to HuggingFace...")

--- a/.github/scripts/validate_submission.py
+++ b/.github/scripts/validate_submission.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Validate leaderboard submission files with sample count verification."""
+"""Validate leaderboard submission files with sample count verification.
+
+Supports partial submissions where not all 4 benchmarks need to be present.
+The workflow will generate parquet files from JSON trajectories, so parquet
+files are optional in the submission.
+"""
 
 from __future__ import annotations
 
@@ -183,17 +188,18 @@ def validate_sample_counts(
                     f"Possible duplicate evaluations or wrong dataset split."
                 )
 
-    # Check if any benchmarks are completely missing
+    # Note: We no longer fail for missing benchmarks - partial submissions are allowed
+    # Only record missing benchmarks for informational purposes
     for benchmark in expected_counts:
         if benchmark not in benchmark_samples and expected_counts[benchmark] is not None:
             if benchmark not in sample_details:
                 sample_details[benchmark] = {
                     "expected": expected_counts[benchmark],
                     "actual": 0,
-                    "valid": False,
+                    "valid": True,  # Not a failure - just not submitted
+                    "not_submitted": True,
                 }
-                checks["sample_count_valid"] = False
-                errors.append(f"{benchmark}: No trajectory files found for this benchmark.")
+                # Don't mark as invalid - partial submissions are OK
 
     return checks, sample_details, errors
 
@@ -385,10 +391,23 @@ def main() -> None:
         result["sample_details"] = sample_details
         result["errors"].extend(count_errors)
 
+        # Check that at least one valid benchmark was found
+        submitted_benchmarks = [
+            b for b, d in sample_details.items()
+            if d.get("actual", 0) > 0 and not d.get("not_submitted", False)
+        ]
+        if not submitted_benchmarks:
+            result["errors"].append(
+                "No valid benchmark trajectories found. "
+                "At least one benchmark (teleqna, telelogs, telemath, 3gpp_tsg) required."
+            )
+
     # Check that we found required files
+    # Note: Parquet is now optional - workflow will generate it from trajectories
     if not parquet_found:
-        result["checks"]["parquet_exists"] = False
-        result["errors"].append("No parquet file found in submission")
+        # Don't fail - workflow will generate parquet from JSON trajectories
+        result["checks"]["parquet_exists"] = True  # Will be generated
+        # No error - this is expected for new submission flow
 
     if not json_files:
         result["checks"]["json_valid"] = False

--- a/.github/workflows/approval-sync.yaml
+++ b/.github/workflows/approval-sync.yaml
@@ -112,6 +112,64 @@ jobs:
           python .github/scripts/sync_to_huggingface.py \
             --files "${{ steps.find-parquet.outputs.files }}"
 
+      - name: Post sync report
+        if: steps.find-parquet.outputs.files != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const prNumber = context.payload.pull_request.number;
+
+            let report;
+            try {
+              report = JSON.parse(fs.readFileSync('sync_report.json', 'utf8'));
+            } catch (e) {
+              report = {};
+            }
+
+            let body = '### Sync Report\n\n';
+
+            if (report.new_models && report.new_models.length > 0) {
+              body += '**New models added:**\n';
+              for (const model of report.new_models) {
+                body += `- ${model}\n`;
+              }
+              body += '\n';
+            }
+
+            if (report.updated_models && report.updated_models.length > 0) {
+              body += '**Models updated:**\n';
+              for (const model of report.updated_models) {
+                body += `- ${model}\n`;
+              }
+              body += '\n';
+            }
+
+            if (report.updated_scores && report.updated_scores.length > 0) {
+              body += '**Scores updated:**\n';
+              for (const score of report.updated_scores) {
+                body += `- ${score}\n`;
+              }
+              body += '\n';
+            }
+
+            if (report.preserved_scores && report.preserved_scores.length > 0) {
+              body += '**Existing scores preserved:**\n';
+              for (const score of report.preserved_scores) {
+                body += `- ${score}\n`;
+              }
+            }
+
+            // Only post if there's something to report
+            if (body !== '### Sync Report\n\n') {
+              await github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              });
+            }
+
       - name: Calculate and update TCI
         if: steps.find-parquet.outputs.files != ''
         env:

--- a/.github/workflows/validate-submission.yaml
+++ b/.github/workflows/validate-submission.yaml
@@ -12,16 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: read
+      contents: write  # Need write to commit generated parquet
 
     outputs:
       validation_passed: ${{ steps.set-output.outputs.passed }}
 
     steps:
-      - name: Checkout
+      - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.head_ref }}  # Checkout PR branch for committing
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -40,13 +42,71 @@ jobs:
             model_cards/**
             trajectories/**
 
+      - name: Find trajectory directories
+        id: find-trajectories
+        run: |
+          TRAJ_DIRS=""
+          for dir in trajectories/*/; do
+            if [ -d "$dir" ]; then
+              JSON_COUNT=$(find "$dir" -name "*.json" -type f 2>/dev/null | wc -l)
+              if [ "$JSON_COUNT" -gt 0 ]; then
+                TRAJ_DIRS="$TRAJ_DIRS $dir"
+              fi
+            fi
+          done
+          TRAJ_DIRS=$(echo "$TRAJ_DIRS" | xargs)  # Trim whitespace
+          echo "dirs=$TRAJ_DIRS" >> $GITHUB_OUTPUT
+          echo "Found trajectory directories: $TRAJ_DIRS"
+
+      - name: Generate parquet from trajectories
+        id: generate-parquet
+        if: steps.find-trajectories.outputs.dirs != ''
+        run: |
+          GENERATED_FILES=""
+          for dir in ${{ steps.find-trajectories.outputs.dirs }}; do
+            DIR_NAME=$(basename "$dir")
+            OUTPUT_PATH="model_cards/${DIR_NAME}.parquet"
+
+            # Skip if parquet already exists
+            if [ -f "$OUTPUT_PATH" ]; then
+              echo "Parquet already exists: $OUTPUT_PATH"
+              continue
+            fi
+
+            echo "Generating parquet for $dir..."
+            python .github/scripts/json_to_parquet.py \
+              --trajectory-dir "$dir" \
+              --output-dir "model_cards/"
+
+            if [ -f "$OUTPUT_PATH" ]; then
+              GENERATED_FILES="$GENERATED_FILES $OUTPUT_PATH"
+              echo "Generated: $OUTPUT_PATH"
+            fi
+          done
+          GENERATED_FILES=$(echo "$GENERATED_FILES" | xargs)  # Trim whitespace
+          echo "generated=$GENERATED_FILES" >> $GITHUB_OUTPUT
+
+      - name: Commit generated parquet
+        if: steps.generate-parquet.outputs.generated != ''
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add model_cards/*.parquet
+          git diff --staged --quiet || git commit -m "chore: Generate parquet from trajectory files"
+          git push || echo "Nothing to push"
+
       - name: Validate submission
         id: validate
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
+          # Include both changed files and generated parquet files
+          ALL_FILES="${{ steps.changed-files.outputs.all_changed_files }}"
+          if [ -n "${{ steps.generate-parquet.outputs.generated }}" ]; then
+            ALL_FILES="$ALL_FILES ${{ steps.generate-parquet.outputs.generated }}"
+          fi
           python .github/scripts/validate_submission.py \
-            --files "${{ steps.changed-files.outputs.all_changed_files }}"
+            --files "$ALL_FILES"
         continue-on-error: true
 
       - name: Post validation results
@@ -95,12 +155,20 @@ jobs:
             body += `- [${checks.sample_count_valid ? 'x' : ' '}] Sample counts match expected (no --limit)\n`;
 
             if (validation.sample_details && Object.keys(validation.sample_details).length > 0) {
-              body += '\n### Sample Count Details:\n';
-              for (const [benchmark, detail] of Object.entries(validation.sample_details)) {
-                const icon = detail.valid ? ':white_check_mark:' : ':x:';
-                const expected = detail.expected === 'unknown' ? '?' : detail.expected;
-                const skipped = detail.skipped ? ' *(validation skipped)*' : '';
-                body += `- ${icon} **${benchmark}**: ${detail.actual} / ${expected} samples${skipped}\n`;
+              body += '\n### Benchmark Status:\n';
+              const allBenchmarks = ['teleqna', 'telelogs', 'telemath', '3gpp_tsg'];
+              for (const benchmark of allBenchmarks) {
+                const detail = validation.sample_details[benchmark];
+                if (!detail) {
+                  body += `- :grey_question: **${benchmark}**: Not submitted\n`;
+                } else if (detail.not_submitted) {
+                  body += `- :grey_question: **${benchmark}**: Not submitted\n`;
+                } else {
+                  const icon = detail.valid ? ':white_check_mark:' : ':x:';
+                  const expected = detail.expected === 'unknown' ? '?' : detail.expected;
+                  const skipped = detail.skipped ? ' *(validation skipped)*' : '';
+                  body += `- ${icon} **${benchmark}**: ${detail.actual} / ${expected} samples${skipped}\n`;
+                }
               }
             }
 


### PR DESCRIPTION
## Summary
Enable users to submit partial benchmark evaluations (1-4 benchmarks) and intelligently merge with existing HuggingFace leaderboard data.

Fixes #12

## Changes Made

### 1. New script: `json_to_parquet.py`
- Converts JSON trajectory files to parquet format during validation
- Extracts scores from `results.scores[0].metrics.accuracy.value`
- Maps task names to benchmark columns
- Supports partial benchmarks (null for missing)

### 2. Modified: `validate_submission.py`
- Removed requirement for ALL 4 benchmarks (partial submissions allowed)
- Made parquet file optional (workflow generates it)
- Added check for at least one valid benchmark
- Missing benchmarks marked as `not_submitted` instead of failing

### 3. Modified: `validate-submission.yaml`
- Added `contents: write` permission for committing parquet
- Checkouts PR branch for committing
- Added steps to find trajectory directories and generate parquet
- Commits generated parquet to PR branch
- Updated validation results to show "Not submitted" for missing benchmarks

### 4. Modified: `sync_to_huggingface.py`
- Replaced simple merge with intelligent `merge_with_preservation()`
- Only updates submitted benchmark columns
- Preserves existing scores for non-submitted benchmarks
- Generates `sync_report.json` with what was updated/preserved

### 5. Modified: `approval-sync.yaml`
- Added "Post sync report" step after HF sync
- Posts comment showing new models, updated scores, and preserved scores

## Test Plan
- [x] Submit PR with only 1 benchmark trajectory → parquet generated with only that score
- [x] Validation should pass for partial submission
- [x] Existing model: submit missing benchmark → fills in null, preserves existing
- [x] Existing model: re-submit benchmark → updates score
- [x] Sync report shows correct new/updated/preserved scores

---
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>