### PR TITLE
Fix HF sync schema alignment and partial avg_score

### DIFF
--- a/.github/scripts/calculate_avg_score.py
+++ b/.github/scripts/calculate_avg_score.py
@@ -13,8 +13,10 @@ import sys
 import pandas as pd
 from datasets import Dataset, load_dataset
 
+from registry import get_benchmark_columns
+
 DATASET_REPO = "GSMA/leaderboard"
-BENCHMARK_COLUMNS = ["teleqna", "telelogs", "telemath", "3gpp_tsg", "teletables"]
+BENCHMARK_COLUMNS = get_benchmark_columns()
 
 
 def extract_score(value: object) -> float | None:
@@ -28,19 +30,23 @@ def extract_score(value: object) -> float | None:
 
 
 def compute_avg_score(row: pd.Series) -> list[float] | None:
-    """Compute average score across all benchmarks for a single row.
+    """Compute average score across available benchmarks for a single row.
 
-    Returns [avg, 0, 0] to match benchmark column format, or None if any
-    benchmark is missing.
+    Returns [avg, 0, n_benchmarks] to match benchmark column format, where
+    n_benchmarks indicates how many scores contributed to the average.
+    Returns None only if zero valid scores exist.
     """
     scores = [extract_score(row.get(col)) for col in BENCHMARK_COLUMNS]
+    valid = [(col, s) for col, s in zip(BENCHMARK_COLUMNS, scores) if s is not None]
     missing = [col for col, s in zip(BENCHMARK_COLUMNS, scores) if s is None]
     if missing:
         model = row.get("model", "unknown")
-        print(f"Warning: {model} missing benchmarks: {', '.join(missing)}")
+        print(f"Info: {model} missing benchmarks: {', '.join(missing)} "
+              f"(averaging {len(valid)}/{len(BENCHMARK_COLUMNS)})")
+    if not valid:
         return None
-    avg = sum(scores) / len(scores)
-    return [avg, 0, 0]
+    avg = sum(s for _, s in valid) / len(valid)
+    return [avg, 0, len(valid)]
 
 
 def load_leaderboard(token: str) -> pd.DataFrame:
@@ -72,6 +78,12 @@ def main() -> None:
     if "tci" in df.columns:
         print("Archiving legacy 'tci' column as 'tci_legacy'")
         df = df.rename(columns={"tci": "tci_legacy"})
+
+    # Backfill missing benchmark columns so compute_avg_score sees them
+    for col in BENCHMARK_COLUMNS:
+        if col not in df.columns:
+            print(f"Adding missing benchmark column: {col}")
+            df[col] = None
 
     print("Computing average scores...")
     df["avg_score"] = df.apply(compute_avg_score, axis=1)

--- a/.github/scripts/sync_to_huggingface.py
+++ b/.github/scripts/sync_to_huggingface.py
@@ -67,6 +67,16 @@ def merge_submissions(
     if new_df.empty:
         return existing_df.copy(), sync_report
 
+    # Align columns: union of both DataFrames, preserving order (existing first)
+    all_columns = list(dict.fromkeys(
+        existing_df.columns.tolist() + new_df.columns.tolist()
+    ))
+    for col in all_columns:
+        if col not in existing_df.columns:
+            existing_df[col] = None
+        if col not in new_df.columns:
+            new_df[col] = None
+
     result_df = existing_df.copy()
     existing_models = set(existing_df["model"].tolist())
 


### PR DESCRIPTION
## Summary

- **sync_to_huggingface.py**: Aligns columns between existing HF dataset and new submissions before merging. Old entries may lack `teletables`, new entries may lack `tci` — column alignment fills missing columns with `None` so `result_df.loc[idx] = new_row` and `pd.concat` work correctly.
- **calculate_avg_score.py**: Imports `BENCHMARK_COLUMNS` from registry instead of hardcoding; averages *available* benchmarks (4/5 for old models, 5/5 for new) instead of returning `None` when any is missing; stores count as `[avg, 0, n_benchmarks]`; backfills missing benchmark columns on HF dataset load.

## Context

The `approval-sync.yaml` workflow fails when syncing to HuggingFace because:
1. Schema mismatch: new submissions include `teletables`, but existing HF entries don't have it
2. `compute_avg_score()` returns `None` for any model missing even one benchmark

## Manual action required

The `HF_TOKEN` GitHub secret contains an OpenRouter API key (`sk-or-v1-...`), not a HuggingFace token. You must:
1. Generate a HF **write** token at https://huggingface.co/settings/tokens
2. Update the `HF_TOKEN` secret in repo settings
3. Rotate the exposed OpenRouter key

## Test plan

- [x] Local test: merge_submissions with mismatched columns (old has tci, new has teletables)
- [x] Local test: compute_avg_score with 5/5, 4/5, and 0/5 benchmarks
- [x] Local test: update existing model when column sets differ
- [ ] After HF_TOKEN is fixed, trigger `workflow_dispatch` on `approval-sync.yaml`
- [ ] Re-approve PR #23 to verify full approval flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)