### PR TITLE
fix: add oranbench/srsranbench to registry and extend provider list

### DIFF
--- a/.github/scripts/registry.py
+++ b/.github/scripts/registry.py
@@ -28,6 +28,8 @@ BENCHMARK_HF_COLUMNS: dict[str, str] = {
     "telemath": "telemath",
     "three_gpp": "3gpp_tsg",
     "teletables": "teletables",
+    "oranbench": "oranbench",
+    "srsranbench": "srsranbench",
 }
 
 _FETCH_TIMEOUT_SECONDS = 10

--- a/.github/scripts/validate_submission.py
+++ b/.github/scripts/validate_submission.py
@@ -32,6 +32,13 @@ RECOGNIZED_PROVIDERS = [
     "Openrouter",
     "Groq",
     "Fireworks",
+    "Grok",
+    "Perplexity",
+    "Sambanova",
+    "Cloudflare",
+    "Ollama",
+    "Vllm",
+    "Sglang",
 ]
 
 # HuggingFace dataset for expected sample counts


### PR DESCRIPTION
## Summary
- **P0 fix**: Adds `oranbench` and `srsranbench` to `BENCHMARK_HF_COLUMNS` in `registry.py`. Without this, `get_benchmark_to_hf_map()` raises `RuntimeError` for ALL validation runs, blocking every submission since Feb 17 when these benchmarks were added to `gsma-labs/evals`.
- **P2 fix**: Extends `RECOGNIZED_PROVIDERS` in `validate_submission.py` with 7 providers that Satellite already supports: Grok, Perplexity, SambaNova, Cloudflare, Ollama, vLLM, SGLang.

## Context
The last successful submission was PR #26 (Feb 11). Since then, the evals repo added `oranbench` and `srsranbench`, but this repo's registry was not updated — causing a hard crash in validation for all subsequent PRs.

## Test plan
- [ ] Verify `get_benchmark_to_hf_map()` no longer raises with 7 benchmarks
- [ ] Verify a parquet-only submission with oranbench/srsranbench columns passes validation
- [ ] Verify providers like "Ollama" and "Grok" are accepted in model format check

🤖 Generated with [Claude Code](https://claude.com/claude-code)