### PR TITLE
Align leaderboard scripts with HF dataset schema

### DIFF
--- a/.github/scripts/calculate_avg_score.py
+++ b/.github/scripts/calculate_avg_score.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
-"""Calculate average scores for all leaderboard entries and update HuggingFace.
+"""Calculate derived columns for all leaderboard entries and update HuggingFace.
 
-Replaces the IRT-based TCI with a simple arithmetic mean of benchmark scores.
+Computes `average`, `benchmarks_completed`, and `rank` from benchmark scores.
 Called by the approval-sync workflow after syncing parquet files.
 """
 
 from __future__ import annotations
 
+import ast
 import os
 import sys
 
@@ -20,33 +21,69 @@ BENCHMARK_COLUMNS = get_benchmark_columns()
 
 
 def extract_score(value: object) -> float | None:
-    """Extract the primary score from [score, stderr, n_samples] format."""
+    """Extract the primary score from a string-encoded or list score value.
+
+    Handles both new format (string "[score, stderr]") and legacy
+    format (list/array [score, stderr, ...]).
+    """
     if value is None:
         return None
+    if isinstance(value, str):
+        try:
+            parsed = ast.literal_eval(value)
+            if isinstance(parsed, list) and len(parsed) >= 1:
+                return float(parsed[0])
+        except (ValueError, SyntaxError):
+            return None
     try:
         return float(value[0])
     except (TypeError, ValueError, IndexError):
         return None
 
 
-def compute_avg_score(row: pd.Series) -> list[float] | None:
-    """Compute average score across available benchmarks for a single row.
+def compute_derived_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute average, benchmarks_completed, and rank for all rows.
 
-    Returns [avg, 0, n_benchmarks] to match benchmark column format, where
-    n_benchmarks indicates how many scores contributed to the average.
-    Returns None only if zero valid scores exist.
+    - average: arithmetic mean of available benchmark scores (0-1 scale)
+    - benchmarks_completed: count of non-null benchmark columns
+    - rank: 1-based rank by average (descending), ties get same rank
     """
-    scores = [extract_score(row.get(col)) for col in BENCHMARK_COLUMNS]
-    valid = [(col, s) for col, s in zip(BENCHMARK_COLUMNS, scores) if s is not None]
-    missing = [col for col, s in zip(BENCHMARK_COLUMNS, scores) if s is None]
-    if missing:
+    averages = []
+    completed_counts = []
+
+    for _, row in df.iterrows():
+        scores = []
+        n_completed = 0
+        for col in BENCHMARK_COLUMNS:
+            score = extract_score(row.get(col))
+            if score is not None:
+                scores.append(score)
+                n_completed += 1
+
         model = row.get("model", "unknown")
-        print(f"Info: {model} missing benchmarks: {', '.join(missing)} "
-              f"(averaging {len(valid)}/{len(BENCHMARK_COLUMNS)})")
-    if not valid:
-        return None
-    avg = sum(s for _, s in valid) / len(valid)
-    return [avg, 0, len(valid)]
+        missing = [col for col in BENCHMARK_COLUMNS if extract_score(row.get(col)) is None]
+        if missing:
+            print(f"Info: {model} missing benchmarks: {', '.join(missing)} "
+                  f"(averaging {n_completed}/{len(BENCHMARK_COLUMNS)})")
+
+        if scores:
+            averages.append(sum(scores) / len(scores))
+        else:
+            averages.append(None)
+        completed_counts.append(n_completed)
+
+    df["average"] = averages
+    df["benchmarks_completed"] = completed_counts
+
+    # Rank by average descending (None values get no rank)
+    df["rank"] = (
+        df["average"]
+        .rank(ascending=False, method="min", na_option="bottom")
+        .where(df["average"].notna())
+        .astype("Int64")
+    )
+
+    return df
 
 
 def load_leaderboard(token: str) -> pd.DataFrame:
@@ -60,7 +97,7 @@ def load_leaderboard(token: str) -> pd.DataFrame:
 
 
 def main() -> None:
-    """Calculate average scores and push to HuggingFace."""
+    """Calculate derived columns and push to HuggingFace."""
     hf_token = os.environ.get("HF_TOKEN")
     if not hf_token:
         print("Error: HF_TOKEN environment variable required")
@@ -71,25 +108,28 @@ def main() -> None:
     print(f"Loaded {len(df)} entries")
 
     if df.empty:
-        print("Dataset is empty, skipping average score calculation")
+        print("Dataset is empty, skipping derived column calculation")
         sys.exit(0)
 
-    # Archive legacy TCI column if it exists (preserve historical data)
+    # Archive legacy columns if they exist (preserve historical data)
     if "tci" in df.columns:
         print("Archiving legacy 'tci' column as 'tci_legacy'")
         df = df.rename(columns={"tci": "tci_legacy"})
+    if "avg_score" in df.columns:
+        print("Archiving legacy 'avg_score' column as 'avg_score_legacy'")
+        df = df.rename(columns={"avg_score": "avg_score_legacy"})
 
-    # Backfill missing benchmark columns so compute_avg_score sees them
+    # Backfill missing benchmark columns so compute sees them
     for col in BENCHMARK_COLUMNS:
         if col not in df.columns:
             print(f"Adding missing benchmark column: {col}")
             df[col] = None
 
-    print("Computing average scores...")
-    df["avg_score"] = df.apply(compute_avg_score, axis=1)
+    print("Computing derived columns (average, benchmarks_completed, rank)...")
+    df = compute_derived_columns(df)
 
-    scored = df["avg_score"].notna().sum()
-    print(f"Computed average score for {scored}/{len(df)} models")
+    scored = df["average"].notna().sum()
+    print(f"Computed scores for {scored}/{len(df)} models")
 
     # Clean up index columns before upload
     index_cols = [c for c in df.columns if c.startswith("__index_level")]
@@ -100,7 +140,7 @@ def main() -> None:
     print("Uploading to HuggingFace...")
     dataset = Dataset.from_pandas(df)
     dataset.push_to_hub(DATASET_REPO, token=hf_token)
-    print(f"Successfully updated {DATASET_REPO} with avg_score column")
+    print(f"Successfully updated {DATASET_REPO} with derived columns")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/json_to_parquet.py
+++ b/.github/scripts/json_to_parquet.py
@@ -120,18 +120,14 @@ def parse_trajectory_json(json_path: Path) -> dict | None:
         print(f"Warning: No accuracy value in {json_path.name}")
         return None
 
-    # Convert to percentage (scores are stored as 0-1 in JSON, 0-100 in parquet)
-    score = accuracy * 100
-    stderr_val = (stderr * 100) if stderr else 0.0
-
-    # Get n_samples
-    n_samples = results.get("total_samples", 0)
+    # Keep scores at 0-1 scale to match HuggingFace dataset schema
+    score = round(accuracy, 6)
+    stderr_val = round(stderr, 6) if stderr else 0.0
 
     return {
         "benchmark": benchmark,
-        "score": round(score, 2),
-        "stderr": round(stderr_val, 6),
-        "n_samples": float(n_samples),
+        "score": score,
+        "stderr": stderr_val,
         "model_name": model_name,
         "provider": provider,
     }
@@ -175,9 +171,12 @@ def generate_parquet(
                 f"{model_name} ({provider}) vs {data['model_name']} ({data['provider']})"
             )
 
-    # Build row with score arrays [score, stderr, n_samples]
+    # Build row with string-encoded scores "[score, stderr]" at 0-1 scale
     task_to_column = get_benchmark_to_hf_map()
-    row: dict = {"model": f"{model_name} ({provider})"}
+    row: dict = {
+        "model": model_name,
+        "provider": provider,
+    }
     for hf_col in task_to_column.values():
         row[hf_col] = None
     row["date"] = date.today().isoformat()
@@ -185,8 +184,7 @@ def generate_parquet(
     benchmarks_found = []
     for data in parsed_data:
         benchmark = data["benchmark"]
-        score_array = [data["score"], data["stderr"], data["n_samples"]]
-        row[benchmark] = score_array
+        row[benchmark] = str([data["score"], data["stderr"]])
         benchmarks_found.append(benchmark)
 
     # Create DataFrame and save
@@ -196,7 +194,6 @@ def generate_parquet(
     return {
         "model_name": model_name,
         "provider": provider,
-        "display_name": f"{model_name} ({provider})",
         "benchmarks_found": benchmarks_found,
         "benchmarks_missing": [b for b in task_to_column.values() if b not in benchmarks_found],
         "output_path": str(output_path),
@@ -244,7 +241,7 @@ def main() -> None:
     try:
         result = generate_parquet(json_files, output_path)
         print(f"Generated parquet: {result['output_path']}")
-        print(f"Model: {result['display_name']}")
+        print(f"Model: {result['model_name']} (Provider: {result['provider']})")
         print(f"Benchmarks found: {', '.join(result['benchmarks_found'])}")
         if result["benchmarks_missing"]:
             print(f"Benchmarks missing: {', '.join(result['benchmarks_missing'])}")

--- a/.github/scripts/registry.py
+++ b/.github/scripts/registry.py
@@ -6,7 +6,7 @@ All leaderboard scripts import from here instead of hardcoding benchmark lists.
 
 The registry dynamically fetches ``__all__`` from the evals repo's
 ``_registry.py`` and validates it against a local mapping that translates
-task names to HF column names (e.g. ``three_gpp`` -> ``3gpp_tsg``).
+task names to HF column names (matching benchmark IDs).
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ BENCHMARK_HF_COLUMNS: dict[str, str] = {
     "teleqna": "teleqna",
     "telelogs": "telelogs",
     "telemath": "telemath",
-    "three_gpp": "3gpp_tsg",
+    "three_gpp": "three_gpp",
     "teletables": "teletables",
 }
 
@@ -114,10 +114,10 @@ def get_required_columns() -> list[str]:
     """Return the full list of required parquet/leaderboard columns.
 
     Returns:
-        ``["model", <hf_columns...>, "date"]``
+        ``["model", "provider", <hf_columns...>, "date"]``
     """
     hf_map = get_benchmark_to_hf_map()
-    return ["model", *sorted(hf_map.values()), "date"]
+    return ["model", "provider", *sorted(hf_map.values()), "date"]
 
 
 def get_benchmark_columns() -> list[str]:

--- a/.github/scripts/sync_to_huggingface.py
+++ b/.github/scripts/sync_to_huggingface.py
@@ -2,12 +2,14 @@
 """Sync validated submissions to HuggingFace dataset.
 
 All benchmarks are required for submission. Existing models are overwritten
-with new scores.
+with new scores. Derived columns (rank, average, benchmarks_completed) are
+computed after merge.
 """
 
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import os
 import sys
@@ -16,7 +18,65 @@ from pathlib import Path
 import pandas as pd
 from datasets import Dataset
 
+from registry import get_benchmark_columns
+
 DATASET_REPO = "GSMA/leaderboard"
+BENCHMARK_COLUMNS = get_benchmark_columns()
+
+
+def _extract_score(value: object) -> float | None:
+    """Extract the primary score from a string-encoded or list score value."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            parsed = ast.literal_eval(value)
+            if isinstance(parsed, list) and len(parsed) >= 1:
+                return float(parsed[0])
+        except (ValueError, SyntaxError):
+            return None
+    try:
+        return float(value[0])
+    except (TypeError, ValueError, IndexError):
+        return None
+
+
+def compute_derived_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute rank, average, and benchmarks_completed after merge.
+
+    - average: arithmetic mean of available benchmark scores (0-1 scale)
+    - benchmarks_completed: count of non-null benchmark columns
+    - rank: 1-based rank by average (descending), ties get same rank
+    """
+    averages = []
+    completed_counts = []
+
+    for _, row in df.iterrows():
+        scores = []
+        n_completed = 0
+        for col in BENCHMARK_COLUMNS:
+            score = _extract_score(row.get(col))
+            if score is not None:
+                scores.append(score)
+                n_completed += 1
+        if scores:
+            averages.append(sum(scores) / len(scores))
+        else:
+            averages.append(None)
+        completed_counts.append(n_completed)
+
+    df["average"] = averages
+    df["benchmarks_completed"] = completed_counts
+
+    # Rank by average descending (None values get no rank)
+    df["rank"] = (
+        df["average"]
+        .rank(ascending=False, method="min", na_option="bottom")
+        .where(df["average"].notna())
+        .astype("Int64")
+    )
+
+    return df
 
 
 def load_existing_dataset(token: str) -> pd.DataFrame:
@@ -48,6 +108,9 @@ def merge_submissions(
 ) -> tuple[pd.DataFrame, dict]:
     """Merge new entries into the leaderboard, overwriting existing models.
 
+    Matches on (model, provider) pair to avoid collisions between
+    same-named models from different providers.
+
     Args:
         existing_df: Current leaderboard data
         new_df: New submission data (all benchmark scores required)
@@ -61,7 +124,10 @@ def merge_submissions(
     }
 
     if existing_df.empty:
-        sync_report["new_models"] = new_df["model"].tolist()
+        sync_report["new_models"] = [
+            f"{row['model']} ({row.get('provider', '')})"
+            for _, row in new_df.iterrows()
+        ]
         return new_df.copy(), sync_report
 
     if new_df.empty:
@@ -78,20 +144,29 @@ def merge_submissions(
             new_df[col] = None
 
     result_df = existing_df.copy()
-    existing_models = set(existing_df["model"].tolist())
+
+    # Build set of existing (model, provider) pairs for match
+    existing_keys = set()
+    for _, row in existing_df.iterrows():
+        key = (str(row.get("model", "")), str(row.get("provider", "")))
+        existing_keys.add(key)
 
     for _, new_row in new_df.iterrows():
-        model_name = new_row["model"]
+        model_name = str(new_row.get("model", ""))
+        provider = str(new_row.get("provider", ""))
+        key = (model_name, provider)
+        display = f"{model_name} ({provider})"
 
-        if model_name in existing_models:
-            idx = result_df[result_df["model"] == model_name].index[0]
+        if key in existing_keys:
+            mask = (result_df["model"] == model_name) & (result_df["provider"] == provider)
+            idx = result_df[mask].index[0]
             result_df.loc[idx] = new_row
-            sync_report["updated_models"].append(model_name)
+            sync_report["updated_models"].append(display)
             continue
 
         new_row_df = pd.DataFrame([new_row])
         result_df = pd.concat([result_df, new_row_df], ignore_index=True)
-        sync_report["new_models"].append(model_name)
+        sync_report["new_models"].append(display)
 
     return result_df, sync_report
 
@@ -171,6 +246,9 @@ def main() -> None:
     print(f"Existing entries: {len(existing_df)}")
 
     merged_df, sync_report = merge_submissions(existing_df, new_df)
+
+    # Compute derived columns (rank, average, benchmarks_completed)
+    merged_df = compute_derived_columns(merged_df)
     print(f"Merged entries: {len(merged_df)}")
 
     print("\n=== Sync Report ===")

--- a/.github/scripts/validate_submission.py
+++ b/.github/scripts/validate_submission.py
@@ -9,6 +9,7 @@ files are optional in the submission.
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import os
 import sys
@@ -243,31 +244,57 @@ def validate_parquet(parquet_path: Path) -> tuple[dict[str, bool], list[str]]:
     else:
         checks["parquet_schema"] = True
 
-    # Validate model format: "model_name (Provider)"
+    # Validate model format: short name (no provider in parens)
     model_format_ok = True
     provider_recognized = True
 
     for model in df["model"].unique():
-        if " (" not in model or not model.endswith(")"):
-            errors.append(f"Invalid model format: {model}")
+        if " (" in model and model.endswith(")"):
+            errors.append(
+                f"Invalid model format: {model} — "
+                f"expected short name only (provider goes in 'provider' column)"
+            )
             model_format_ok = False
-        else:
-            provider = model.split("(")[-1].rstrip(")")
-            if provider.lower() not in [p.lower() for p in RECOGNIZED_PROVIDERS]:
+
+    # Validate provider column
+    if "provider" in df.columns:
+        for provider in df["provider"].unique():
+            if provider and provider.lower() not in [p.lower() for p in RECOGNIZED_PROVIDERS]:
                 errors.append(f"Unrecognized provider: {provider}")
                 provider_recognized = False
+    else:
+        errors.append("Missing required 'provider' column")
+        provider_recognized = False
 
     checks["model_format"] = model_format_ok
     checks["provider_recognized"] = provider_recognized
 
-    # Validate score arrays (can be list, tuple, or numpy array from parquet)
+    # Validate score format: string-encoded "[score, stderr]"
     for col in get_benchmark_columns():
         if col not in df.columns:
             continue
         for idx, val in df[col].items():
-            if val is not None:
-                if not isinstance(val, (list, tuple, np.ndarray)) or len(val) < 2:
-                    errors.append(f"Invalid score format in {col} row {idx}: expected [score, stderr, ...]")
+            if val is None:
+                continue
+            if isinstance(val, str):
+                try:
+                    parsed = ast.literal_eval(val)
+                    if not isinstance(parsed, list) or len(parsed) != 2:
+                        errors.append(
+                            f"Invalid score format in {col} row {idx}: "
+                            f"expected \"[score, stderr]\", got {val!r}"
+                        )
+                except (ValueError, SyntaxError):
+                    errors.append(
+                        f"Cannot parse score in {col} row {idx}: {val!r}"
+                    )
+            elif isinstance(val, (list, tuple, np.ndarray)) and len(val) >= 2:
+                pass  # Legacy format — still accept for backward compat
+            else:
+                errors.append(
+                    f"Invalid score format in {col} row {idx}: "
+                    f"expected string-encoded \"[score, stderr]\""
+                )
 
     return checks, errors
 
@@ -276,11 +303,12 @@ def validate_sample_counts_from_parquet(
     files: list[str],
     expected_counts: dict[str, int | None],
 ) -> tuple[dict[str, bool], dict[str, dict], list[str]]:
-    """Validate sample counts from parquet score arrays.
+    """Validate benchmark presence from parquet score columns.
 
-    For parquet-only submissions, each benchmark column stores
-    [score, stderr, n_samples]. Extract n_samples and compare
-    against expected counts from HuggingFace.
+    For parquet-only submissions, scores are string-encoded "[score, stderr]"
+    without n_samples. Sample count validation is done client-side by Satellite
+    before submission. Here we only verify that benchmark columns are present
+    and contain valid score data.
 
     Args:
         files: List of file paths from the submission.
@@ -296,8 +324,8 @@ def validate_sample_counts_from_parquet(
     # Column name -> benchmark key mapping (reverse of registry map)
     column_to_benchmark = {v: k for k, v in get_benchmark_to_hf_map().items()}
 
-    # Read all parquet files
-    benchmark_samples: dict[str, int] = {}
+    # Read all parquet files and check which benchmarks have valid scores
+    benchmarks_present: set[str] = set()
     for file_path in files:
         path = Path(file_path)
         if path.suffix != ".parquet" or not path.exists():
@@ -313,71 +341,42 @@ def validate_sample_counts_from_parquet(
             for val in df[col]:
                 if val is None:
                     continue
-                if isinstance(val, (list, tuple, np.ndarray)) and len(val) >= 3:
-                    benchmark_key = column_to_benchmark.get(col, col)
+                benchmark_key = column_to_benchmark.get(col, col)
+                # Accept both string-encoded and legacy list formats
+                if isinstance(val, str):
                     try:
-                        count = int(val[2])
-                    except (TypeError, ValueError):
-                        errors.append(f"Invalid sample count in {col}: {val[2]}")
-                        continue
-                    if benchmark_key in benchmark_samples and benchmark_samples[benchmark_key] != count:
-                        errors.append(
-                            f"Inconsistent sample counts for {col}: "
-                            f"{benchmark_samples[benchmark_key]} vs {count}"
-                        )
-                    benchmark_samples[benchmark_key] = count
+                        parsed = ast.literal_eval(val)
+                        if isinstance(parsed, list) and len(parsed) >= 2:
+                            benchmarks_present.add(benchmark_key)
+                    except (ValueError, SyntaxError):
+                        errors.append(f"Cannot parse score in {col}: {val!r}")
+                elif isinstance(val, (list, tuple, np.ndarray)) and len(val) >= 2:
+                    benchmarks_present.add(benchmark_key)
 
-    # Validate counts
-    for benchmark, expected in expected_counts.items():
-        if expected is None:
+    # Validate that benchmarks are present
+    for benchmark in expected_counts:
+        if benchmark in benchmarks_present:
             sample_details[benchmark] = {
-                "expected": "unknown",
-                "actual": benchmark_samples.get(benchmark, 0),
+                "expected": expected_counts[benchmark] or "unknown",
+                "actual": "present",
                 "valid": True,
-                "skipped": True,
             }
-            continue
-
-        actual_count = benchmark_samples.get(benchmark, 0)
-        is_valid = actual_count == expected
-
-        sample_details[benchmark] = {
-            "expected": expected,
-            "actual": actual_count,
-            "valid": is_valid,
-        }
-
-        if not is_valid:
-            if actual_count == 0:
-                sample_details[benchmark]["not_submitted"] = True
-                sample_details[benchmark]["valid"] = True
-                # Do NOT reset checks here — prior failures must persist
-            elif actual_count < expected:
-                checks["sample_count_valid"] = False
-                errors.append(
-                    f"{benchmark}: Only {actual_count}/{expected} samples evaluated. "
-                    f"Did you use --limit? Full benchmark required for submission."
-                )
-            elif actual_count > expected:
-                checks["sample_count_valid"] = False
-                errors.append(
-                    f"{benchmark}: {actual_count} samples found, expected {expected}. "
-                    f"Possible duplicate evaluations or wrong dataset split."
-                )
+        else:
+            sample_details[benchmark] = {
+                "expected": expected_counts[benchmark] or "unknown",
+                "actual": 0,
+                "valid": True,
+                "not_submitted": True,
+            }
 
     # Ensure at least one benchmark was actually submitted
-    submitted = [
-        b for b, d in sample_details.items()
-        if d.get("actual", 0) > 0 and not d.get("not_submitted", False)
-    ]
-    if not submitted:
+    if not benchmarks_present:
         errors.append(
             "No valid benchmark data found in parquet. "
             "At least one benchmark required."
         )
         checks["sample_count_valid"] = False
 
-    # Re-evaluate overall validity after processing all benchmarks
     if errors:
         checks["sample_count_valid"] = False
 


### PR DESCRIPTION
## Summary

- Fix `three_gpp` column mapping in registry (`three_gpp` not `3gpp_tsg`)
- Add `provider` to required columns and validate separate `model`/`provider` fields
- Accept string-encoded `"[score, stderr]"` score format at 0-1 scale
- Match on `(model, provider)` pair in sync to avoid collisions between providers
- Compute derived columns (`rank`, `average`, `benchmarks_completed`) post-merge
- Update `json_to_parquet` and `calculate_avg_score` for new format

Companion to gsma-labs/satellite `feature/mwc_update` branch (satellite#39).

## Test plan

- [ ] Verify `registry.py` returns `three_gpp` (not `3gpp_tsg`) from `get_benchmark_columns()`
- [ ] Validate a parquet with string-encoded scores passes `validate_submission.py`
- [ ] Confirm `sync_to_huggingface.py` correctly merges on `(model, provider)` and computes `rank`/`average`/`benchmarks_completed`
- [ ] Test `json_to_parquet.py` outputs scores at 0-1 scale as strings
- [ ] Test `calculate_avg_score.py` parses string-encoded scores and produces correct averages

🤖 Generated with [Claude Code](https://claude.com/claude-code)